### PR TITLE
Fix #125 Support Docker for Desktop with default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ You will need the following components to get started with Skaffold:
       -  `curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-darwin-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
 
 1. Kubernetes Cluster
-   -  [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) and [GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-container-cluster)
+   -  [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/),
+      [GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-container-cluster),
+      [Docker for Mac (Edge)](https://docs.docker.com/docker-for-mac/install/) and [Docker for Windows (Edge)](https://docs.docker.com/docker-for-windows/install/)
       have been tested but any Kubernetes cluster will work.
 
 1. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
@@ -64,7 +66,8 @@ You will need the following components to get started with Skaffold:
 1. docker
 
 1. Docker image registry
-   -  Your docker client should be configured to push to an external docker image repository. If you're using a minikube cluster, you can skip this requirement.
+   -  Your docker client should be configured to push to an external docker image repository. If you're using a minikube or Docker for Desktop cluster,
+      you can skip this requirement.
    -  If you are using Google Container Registry (GCR), run: `gcloud docker -a`
 
 ### Iterative Development
@@ -75,7 +78,7 @@ From the root directory of this repository.
 ```console
 $ skaffold dev -f examples/getting-started/skaffold.yaml
 Starting build...
-Found minikube context, using minikube docker daemon.
+Found minikube or Docker for Desktop context, using local docker daemon.
 Sending build context to Docker daemon   7.68kB
 Step 1/5 : FROM golang:1.9.4-alpine3.7
  ---> fb6e10bf973b

--- a/examples/getting-started/skaffold.yaml
+++ b/examples/getting-started/skaffold.yaml
@@ -24,9 +24,9 @@ build:
   # This next section is where you'll put your specific builder configuration.
   # Here, we're using a local builder, which simply builds using the host docker
 
-  # If you're using minikube, you can skip the push step for even faster build
-  # and deploy cycles.
-  # local: {} # Use this for minikube configuration
+  # If you're using minikube or Docker for Desktop, you can skip the push step
+  # for even faster build and deploy cycles.
+  # local: {} # Use this for minikube or Docker for Desktop configuration
   local: {}
     # Skaffold defers to your ~/.docker/config for authentication information
     # If you're using GCR, make sure that you have gcloud and

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -34,8 +34,9 @@ const (
 	TagStrategySha256    = "sha256"
 	TagStrategyGitCommit = "gitCommit"
 
-	DefaultMinikubeContext = "minikube"
-	GCSBucketSuffix        = "_cloudbuild"
+	DefaultMinikubeContext         = "minikube"
+	DefaultDockerForDesktopContext = "docker-for-desktop"
+	GCSBucketSuffix                = "_cloudbuild"
 
 	// TerminalBell is the sequence that triggers a beep in the terminal
 	TerminalBell = "\007"


### PR DESCRIPTION
Like on Minikube, images don't need to be pushed to be deployed in dev mode
with Docker for Desktop.

Signed-off-by: David Gageot <david@gageot.net>